### PR TITLE
Fix Adafruit_DHT plugin to support °F and configurable DHT22 and DHT11 selection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,6 +36,9 @@ class AdafruitDHTSensor(SensorPassive):
             if self.type == "humidity":
                 self.data_received(round(humidity, 2))
             if self.type == "temperature":
-                self.data_received(round(temperature, 2))
+                if self.get_config_parameter("unit", "C") == "C":
+                    self.data_received(round(temperature, 2))
+                else:
+                    self.data_received(round(9.0 / 5.0 * temperature + 32, 2))                
         except Exception as e:
             self.api.app.logger.error("Adafruit_DHT ERROR")

--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@ class AdafruitDHTSensor(SensorPassive):
 
     gpio = Property.Select("GPIO", options=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27], description="GPIO to which the actor is connected")
     type = Property.Select("TYPE", options=["humidity", "temperature"])
+    sensorType = Property.Select("DHT TYPE", options={"DHT22", "DHT11"])
 
     def get_unit(self):
         '''
@@ -27,8 +28,12 @@ class AdafruitDHTSensor(SensorPassive):
         
         self.api.app.logger.info("Read Adafruit_DHT")
         self.api.app.logger.info("GPIO %s type %s" % (self.gpio, self.type))
+        self.api.app.logger.info("DHT Type %s" % (self.sensorType))
+        if self.sensorType == "DHT22":
+            sensor = Adafruit_DHT.DHT22                                         
+        else:
+            sensor = Adafruit_DHT.DHT11
         try:
-            sensor = Adafruit_DHT.DHT22
             pin = int(self.gpio)
             humidity, temperature = Adafruit_DHT.read_retry(sensor, pin)
             self.api.app.logger.info(humidity)

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ class AdafruitDHTSensor(SensorPassive):
                 
     def read(self):
         
-        self.api.app.logger.info("Read Adafruit_DHT")
+        self.api.app.logger.info("Read Adafruit_DHT: version %s" % (Adafruit_DHT.__version__))
         self.api.app.logger.info("GPIO %s type %s" % (self.gpio, self.type))
         self.api.app.logger.info("DHT Type %s" % (self.sensorType))
         if self.sensorType == "DHT22":

--- a/__init__.py
+++ b/__init__.py
@@ -21,8 +21,11 @@ class AdafruitDHTSensor(SensorPassive):
         if self.type == "humidity":
             return "%"
         if self.type == "temperature":
-            return "°C"
-
+            if self.get_config_parameter("unit", "C") == "C":
+                    return "°C";
+                else:
+                    return "°F";
+                
     def read(self):
         
         self.api.app.logger.info("Read Adafruit_DHT")
@@ -39,6 +42,6 @@ class AdafruitDHTSensor(SensorPassive):
                 if self.get_config_parameter("unit", "C") == "C":
                     self.data_received(round(temperature, 2))
                 else:
-                    self.data_received(round(9.0 / 5.0 * temperature + 32, 2))                
+                    self.data_received(round(9.0 / 5.0 * temperature + 32, 2))
         except Exception as e:
             self.api.app.logger.error("Adafruit_DHT ERROR")

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ class AdafruitDHTSensor(SensorPassive):
 
     gpio = Property.Select("GPIO", options=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27], description="GPIO to which the actor is connected")
     type = Property.Select("TYPE", options=["humidity", "temperature"])
-    sensorType = Property.Select("DHT TYPE", options={"DHT22", "DHT11"])
+    sensorType = Property.Select("DHT TYPE", options=["DHT22", "DHT11"])
 
     def get_unit(self):
         '''

--- a/__init__.py
+++ b/__init__.py
@@ -44,6 +44,6 @@ class AdafruitDHTSensor(SensorPassive):
                 if self.get_config_parameter("unit", "C") == "C":
                     self.data_received(round(temperature, 2))
                 else:
-                    self.data_received(round(9.0 / 5.0 * temperature + 32, 2))
+                    self.data_received(round((9.0 / 5.0 * temperature) + 32, 2))
         except Exception as e:
             self.api.app.logger.error("Adafruit_DHT ERROR")

--- a/__init__.py
+++ b/__init__.py
@@ -21,10 +21,7 @@ class AdafruitDHTSensor(SensorPassive):
         if self.type == "humidity":
             return "%"
         if self.type == "temperature":
-            if self.get_config_parameter("unit", "C") == "C":
-                    return "°C";
-                else:
-                    return "°F";
+            return "°C" if self.get_config_parameter("unit", "C") == "C" else "°F"
                 
     def read(self):
         


### PR DESCRIPTION
Fixed get_unit and read functions to support both °C and °F temperature readings based on overall configuration.